### PR TITLE
docs: simplificar nome do projeto para 'Caderno'

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,4 +436,4 @@ Contribuições são bem-vindas! Para contribuir:
 
 ---
 
-**Criado com ❤️ usando [MyST Markdown](https://mystmd.org)** | [Documentação](https://mystmd.org) | [GitHub](https://github.com/parahyba/caderno)
+**Criado com ❤️ usando [MyST Markdown](https://mystmd.org)** | [Documentação](https://mystmd.org) | [GitHub](https://github.com/parahyba-com/caderno)

--- a/books/index.md
+++ b/books/index.md
@@ -1,5 +1,5 @@
 ---
-title: Caderno Parahyba
+title: Caderno
 description: Ferramentas e documentação técnica de classe mundial
 keywords:
   - myst

--- a/books/myst.yml
+++ b/books/myst.yml
@@ -1,11 +1,11 @@
 version: 1
 
 project:
-  id: caderno-parahyba
-  title: "Caderno Parahyba"
+  id: caderno
+  title: "Caderno"
   description: "Ferramentas e documentação técnica de classe mundial"
   authors:
-    - name: "Caderno Parahyba Team"
+    - name: "Caderno Team"
   keywords:
     - myst
     - documentação
@@ -39,7 +39,7 @@ project:
 
 site:
   template: book-theme
-  title: "Caderno Parahyba"
+  title: "Caderno"
   
   options:
     # Preservar estrutura de pastas nas URLs (/guia-myst/cap1)
@@ -50,8 +50,8 @@ site:
     hide_outline: false
     
     # Configurações visuais
-    logo_text: "Caderno Parahyba"
+    logo_text: "Caderno"
     
   actions:
     - title: "GitHub"
-      url: https://github.com/parahyba/caderno
+      url: https://github.com/parahyba-com/caderno

--- a/cli.py
+++ b/cli.py
@@ -18,7 +18,7 @@ custom_theme = Theme(
     }
 )
 console = Console(theme=custom_theme)
-app = typer.Typer(help="CLI para gerenciamento do projeto Caderno Parahyba.")
+app = typer.Typer(help="CLI para gerenciamento do projeto Caderno.")
 
 
 def run_command(command: list[str], description: str, check: bool = True, cwd: Path | None = None):


### PR DESCRIPTION
## Descrição

Simplifica o nome do projeto de "Caderno Parahyba" para apenas "Caderno", tornando a identidade do projeto mais direta e menos atrelada a uma localização geográfica específica.

## Tipo de Mudança

- [x] Documentação (atualização de documentação)
- [x] Refatoração (mudança que não adiciona funcionalidade nem corrige bugs)

## Related Issues

Closes #1

## Mudanças Implementadas

- **README.md**: Atualizado título principal e descrição do projeto
- **cli.py**: Simplificado texto de ajuda do CLI
- **books/myst.yml**: 
  - ID do projeto: `caderno-parahyba` → `caderno`
  - Título do projeto: "Caderno Parahyba" → "Caderno"
  - Autor: "Caderno Parahyba Team" → "Caderno Team"
  - Título do site: "Caderno Parahyba" → "Caderno"
  - Logo text: "Caderno Parahyba" → "Caderno"
  - GitHub URL: atualizado para `parahyba-com/caderno`
- **books/index.md**: Atualizado título no frontmatter

## Development Checklist

- [x] Código segue os padrões de estilo do projeto
- [x] Realizei auto-revisão do meu código
- [x] Mudanças não geram novos warnings
- [x] Build passa localmente
- [x] Commits seguem o padrão Conventional Commits

## Commits Checklist

- [x] Commits seguem o formato: `type(scope): subject`
- [x] Tipo válido usado: `docs`
- [x] Subject usa modo imperativo (simplificar)
- [x] Subject em lowercase
- [x] Commit focado (uma mudança lógica)

## Impacto

- **Performance**: Nenhum impacto
- **Accessibility**: Nenhum impacto
- **SEO**: Nenhum impacto
- **Security**: Nenhum impacto